### PR TITLE
Different changes related to `sosta` revision

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sosta
 Title: A package for the analysis of anatomical tissue structures in spatial omics data
-Version: 1.3.2
+Version: 1.3.3
 Authors@R: c(
     person("Samuel", "Gunz", , "samuel.gunz@uzh.ch", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-8909-0932")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sosta
 Title: A package for the analysis of anatomical tissue structures in spatial omics data
-Version: 1.3.1
+Version: 1.3.2
 Authors@R: c(
     person("Samuel", "Gunz", , "samuel.gunz@uzh.ch", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-8909-0932")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sosta
 Title: A package for the analysis of anatomical tissue structures in spatial omics data
-Version: 1.3.0
+Version: 1.3.1
 Authors@R: c(
     person("Samuel", "Gunz", , "samuel.gunz@uzh.ch", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-8909-0932")),

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,6 +3,7 @@
 export(.SPE2df)
 export(.df2ppp)
 export(.intensityImage)
+export(.intensityThreshold)
 export(SPE2ppp)
 export(assingCellsToStructures)
 export(binaryImageToSF)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# sosta 1.3.2
+
+* changed `minBoundaryDistances` to allow for distance to FOV border characterization
+* added "Structure boundary vs FOV boundary" section to vignette.
+
 # sosta 1.3.1
 
 * added argument to simulate noise in `createPointPatternTissue`

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# sosta 1.3.1
+
+* added argument to simulate noise in `createPointPatternTissue`
+* improved intensity value threshold estimation for reconstruction in `.intensityThreshold`
+
+# sosta 1.2.0
+
+* Bioc 3.22 release version
+
 # sosta 1.1.4
 
 * the argument `imageCol` is now not longer needed in reconstruction functions

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# sosta 1.3.3
+
+* clarified difference between `shapeMetric` and `totalShapeMetrics`.
+* updated FOV border characterization in vignette.
+
 # sosta 1.3.2
 
 * changed `minBoundaryDistances` to allow for distance to FOV border characterization

--- a/R/calculateMetrics.R
+++ b/R/calculateMetrics.R
@@ -1,4 +1,8 @@
-#' Calculate a set of shape metrics of a polygon
+#' Calculate a set of shape metrics of a single polygon
+#'
+#' @details
+#' For multiple polyogns or a MULTIPOLYGON object use the function \code{\link{totalShapeMetrics}}
+#'
 #'
 #' @param sfPoly POLYGON of class sfc
 #'
@@ -67,7 +71,7 @@ shapeMetrics <- function(sfPoly) {
 #' @details
 #' Calculate a set of shape metrics of a set of polygons.
 #' The function calculates all metrics that are implemented in the function
-#' `shapeMetrics()`
+#' \code{\link{shapeMetrics}}
 #'
 #' @param sfInput `MULTIPOLYGON` of class sf
 #'

--- a/R/calculateMetrics.R
+++ b/R/calculateMetrics.R
@@ -25,6 +25,8 @@ shapeMetrics <- function(sfPoly) {
     # Input checks
     stopifnot("'sfPoly' must be a valid sfc object" = inherits(sfPoly, "sfc"))
     stopifnot("'sfPoly' must be of type POLYGON" = st_geometry_type(sfPoly) == "POLYGON")
+    stopifnot("'sfPoly' must be a single POLYGON,
+    use `sosta::totalShapeMetrics` for a set of POLYGONs" = length(st_geometry_type(sfPoly)) == 1)
     # Area
     shapeArea <- st_area(sfPoly)
     # Perimeter

--- a/R/cellLevelMetrics.R
+++ b/R/cellLevelMetrics.R
@@ -191,7 +191,7 @@ cellTypeProportions <- function(spe, structColumn, cellTypeColumn, nCores = 1) {
 #'
 #' @param spe SpatialExperiment object
 #' @param imageCol character; name of the `colData` column specifying the image name
-#' @param structColumn character; name of the `colData` column specifying structure assignments
+#' @param structColumn character; name of the `colData` column specifying structure assignments. Default = NULL.
 #' @param allStructs sf object; contains spatial structures with corresponding image names
 #' @param nCores integer; The number of cores to use for parallel processing (default is 1).
 #'
@@ -234,27 +234,30 @@ cellTypeProportions <- function(spe, structColumn, cellTypeColumn, nCores = 1) {
 #'         geom_sf(data = allStructs, fill = NA, inherit.aes = FALSE) +
 #'         facet_wrap(~imageName)
 #' }
-minBoundaryDistances <- function(spe, imageCol,
-    structColumn, allStructs, nCores = 1) {
+minBoundaryDistances <- function(spe,
+                                 imageCol,
+                                 structColumn = NULL,
+                                 allStructs,
+                                 nCores = 1) {
     # Input checking
-    stopifnot(
-        "'spe' must be an object of class 'SpatialExperiment'" =
-            inherits(spe, "SpatialExperiment")
-    )
-    stopifnot(
-        "'allStructs' must be an object of class 'sf'" =
-            inherits(allStructs, "sf")
-    )
+    stopifnot("'spe' must be an object of class 'SpatialExperiment'" =
+                  inherits(spe, "SpatialExperiment"))
+    stopifnot("'allStructs' must be an object of class 'sf'" =
+                  inherits(allStructs, "sf"))
     stopifnot(
         "'imageCol' must be a character string and exist in colData(spe) and colnames(allStructs)'" =
             is.character(imageCol) && length(imageCol) == 1 &&
-                imageCol %in% colnames(colData(spe)) && imageCol %in% colnames(allStructs)
+            imageCol %in% colnames(colData(spe)) &&
+            imageCol %in% colnames(allStructs)
     )
-    stopifnot(
-        "'structColumn' must be a character string and exist in colData(spe)'" =
-            is.character(structColumn) && length(structColumn) == 1 &&
+    if (!is.null(structColumn)) {
+        stopifnot(
+            "'structColumn' must be a character string and exist in colData(spe)'" =
+                !is.null(structColumn) && is.character(structColumn) &&
+                length(structColumn) == 1 &&
                 structColumn %in% colnames(colData(spe))
-    )
+        )
+    }
     stopifnot(
         "'nCores' must be a positive integer'" =
             is.numeric(nCores) && length(nCores) == 1 &&
@@ -304,8 +307,10 @@ minBoundaryDistances <- function(spe, imageCol,
     names(out) <- rd$colnamesSPE
 
     # Negate distances for assigned structures
-    out[colnames(spe)][!is.na(spe[[structColumn]])] <-
-        -out[colnames(spe)][!is.na(spe[[structColumn]])]
+    if (!is.null(structColumn)) {
+        out[colnames(spe)][!is.na(spe[[structColumn]])] <-
+            -out[colnames(spe)][!is.na(spe[[structColumn]])]
+    }
 
     return(out[colnames(spe)])
 }

--- a/R/shapeMetricsFromSF.R
+++ b/R/shapeMetricsFromSF.R
@@ -1,4 +1,4 @@
-#' Calculate the length of feature axes of an sf polygon
+#' Calculate the length of feature axes of a single sf polygon
 #'
 #' @param sfPoly `POLYGON ` of class `sf`
 #' @importFrom sf st_minimum_rotated_rectangle st_coordinates

--- a/R/simulateData.R
+++ b/R/simulateData.R
@@ -42,6 +42,7 @@ simulateTissueBlobs <- function(size, seedNumber, clumpSize) {
 #' @param tissueImage Matrix; A binary matrix representing the simulated tissue.
 #' @param intA Numeric; Intensity of type "A" points (points per unit area) on tissue regions.
 #' @param intB Numeric; Intensity of type "B" points (points per unit area) on non-tissue regions.
+#' @param noiseA Numeric; Intensity of type "A" points (points per unit area) on non-tissue regions.
 #' @param intCInA Numeric; Intensity of type "C" points placed in extended regions around tissue.
 #' @param intCInB Numeric; Intensity of type "C" points placed within tissue.
 #'
@@ -52,10 +53,15 @@ simulateTissueBlobs <- function(size, seedNumber, clumpSize) {
 #'
 #' @examples
 #' tissueImage <- simulateTissueBlobs(128, 100, 7)
-#' createPointPatternTissue(tissueImage, 0.1, 0.1, 0.005, 0.005)
+#' createPointPatternTissue(tissueImage, 0.01, 0.01, 0.005, 0.005, 0.005)
 #'
 #' @export
-createPointPatternTissue <- function(tissueImage, intA, intB, intCInA, intCInB) {
+createPointPatternTissue <- function(tissueImage,
+                                     intA,
+                                     intB,
+                                     noiseA = 0.005,
+                                     intCInA,
+                                     intCInB) {
     # Create a binary image of non-tissue
     nonTissue <- (tissueImage == 0)
 
@@ -66,7 +72,7 @@ createPointPatternTissue <- function(tissueImage, intA, intB, intCInA, intCInB) 
 
     # Create point pattern with noise
     pointsA <- rpoispp(intA, win = tissueWindow)
-    aNoise <- rpoispp(intA / 20, win = extendedWindow)
+    aNoise <- rpoispp(noiseA, win = extendedWindow)
     pointsB <- rpoispp(intB, win = nonTissueWindow)
     pointsC <- rpoispp(intCInA, win = extendedWindow)
     pointsC2 <- rpoispp(intCInB, win = tissueWindow)

--- a/R/utils.R
+++ b/R/utils.R
@@ -369,10 +369,12 @@ findIntensityThreshold <- function(
 #' @param steps numeric; value used to filter the density estimates, where only
 #' densities greater than the maximum value divided by \code{threshold} are considered.
 #' Default is 250.
+#' @param minRange numeric; value used to filter minimal threshold in percent of
+#' total range. Should range between (0,1].
 #'
 #' @return numeric; estimated threshold
 #' @importFrom stats density
-.intensityThreshold <- function(densityImage, steps = 250) {
+.intensityThreshold <- function(densityImage, steps = 250, minRange = 0.15) {
     # take all densities greater than certain threshold due to numerical properties
     # of the density estimation
     denDf <- densityImage |> as.data.frame()
@@ -381,7 +383,11 @@ findIntensityThreshold <- function(
     peaks <- newDen$x[which(diff(sign(diff(newDen$y))) == -2)]
     # define peak values
     peakVals <- newDen$y[which(diff(sign(diff(newDen$y))) == -2)]
+    peakVals <- peakVals /  max(newDen$y)
+    # filter very small values
+    peaks <- peaks[peakVals > 0.05]
     # the threshold is the mean between the two main modes of the distribution
+    # if there is only one mode, this is the value.
     if (length(peaks) == 1) {
         thres <- peaks
     } else {
@@ -389,7 +395,13 @@ findIntensityThreshold <- function(
             peaks[order(peaks, decreasing = FALSE)[1]]) / 2 +
             peaks[order(peaks, decreasing = FALSE)[1]]
     }
-    return(thres)
+    # added min threshold: at least minRange of intensity range
+    minThres <- diff(range(newDen$x)) * minRange
+    if(thres < minThres) {
+        message(paste0("Minimal threshold: ", minRange*100, "% of intensity range used.
+                       Consider manually adjusting the intensity threshold"))
+    }
+    return(max(thres, minThres))
 }
 
 #' Function to convert spatialCoords to an sf object

--- a/R/utils.R
+++ b/R/utils.R
@@ -374,6 +374,7 @@ findIntensityThreshold <- function(
 #'
 #' @return numeric; estimated threshold
 #' @importFrom stats density
+#' @export
 .intensityThreshold <- function(densityImage, steps = 250, minRange = 0.15) {
     # take all densities greater than certain threshold due to numerical properties
     # of the density estimation

--- a/man/createPointPatternTissue.Rd
+++ b/man/createPointPatternTissue.Rd
@@ -4,7 +4,14 @@
 \alias{createPointPatternTissue}
 \title{Create a Point Pattern on a Simulated Tissue Image}
 \usage{
-createPointPatternTissue(tissueImage, intA, intB, intCInA, intCInB)
+createPointPatternTissue(
+  tissueImage,
+  intA,
+  intB,
+  noiseA = 0.005,
+  intCInA,
+  intCInB
+)
 }
 \arguments{
 \item{tissueImage}{Matrix; A binary matrix representing the simulated tissue.}
@@ -12,6 +19,8 @@ createPointPatternTissue(tissueImage, intA, intB, intCInA, intCInB)
 \item{intA}{Numeric; Intensity of type "A" points (points per unit area) on tissue regions.}
 
 \item{intB}{Numeric; Intensity of type "B" points (points per unit area) on non-tissue regions.}
+
+\item{noiseA}{Numeric; Intensity of type "A" points (points per unit area) on non-tissue regions.}
 
 \item{intCInA}{Numeric; Intensity of type "C" points placed in extended regions around tissue.}
 
@@ -25,6 +34,6 @@ This function generates a spatial point pattern with different types of points (
 }
 \examples{
 tissueImage <- simulateTissueBlobs(128, 100, 7)
-createPointPatternTissue(tissueImage, 0.1, 0.1, 0.005, 0.005)
+createPointPatternTissue(tissueImage, 0.01, 0.01, 0.005, 0.005, 0.005)
 
 }

--- a/man/dot-intensityThreshold.Rd
+++ b/man/dot-intensityThreshold.Rd
@@ -4,7 +4,7 @@
 \alias{.intensityThreshold}
 \title{Function to estimate the intensity threshold for the reconstruction of spatial structures}
 \usage{
-.intensityThreshold(densityImage, steps = 250)
+.intensityThreshold(densityImage, steps = 250, minRange = 0.15)
 }
 \arguments{
 \item{densityImage}{real-valued pixel image; output from the function \code{.intensityImage}}
@@ -12,6 +12,9 @@
 \item{steps}{numeric; value used to filter the density estimates, where only
 densities greater than the maximum value divided by \code{threshold} are considered.
 Default is 250.}
+
+\item{minRange}{numeric; value used to filter minimal threshold in percent of
+total range. Should range between (0,1].}
 }
 \value{
 numeric; estimated threshold

--- a/man/minBoundaryDistances.Rd
+++ b/man/minBoundaryDistances.Rd
@@ -4,14 +4,20 @@
 \alias{minBoundaryDistances}
 \title{Compute minimum boundary distances for each cell within its corresponding image structures}
 \usage{
-minBoundaryDistances(spe, imageCol, structColumn, allStructs, nCores = 1)
+minBoundaryDistances(
+  spe,
+  imageCol,
+  structColumn = NULL,
+  allStructs,
+  nCores = 1
+)
 }
 \arguments{
 \item{spe}{SpatialExperiment object}
 
 \item{imageCol}{character; name of the \code{colData} column specifying the image name}
 
-\item{structColumn}{character; name of the \code{colData} column specifying structure assignments}
+\item{structColumn}{character; name of the \code{colData} column specifying structure assignments. Default = NULL.}
 
 \item{allStructs}{sf object; contains spatial structures with corresponding image names}
 

--- a/man/shapeMetrics.Rd
+++ b/man/shapeMetrics.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/calculateMetrics.R
 \name{shapeMetrics}
 \alias{shapeMetrics}
-\title{Calculate a set of shape metrics of a polygon}
+\title{Calculate a set of shape metrics of a single polygon}
 \usage{
 shapeMetrics(sfPoly)
 }
@@ -13,7 +13,10 @@ shapeMetrics(sfPoly)
 list; list of shape metrics
 }
 \description{
-Calculate a set of shape metrics of a polygon
+Calculate a set of shape metrics of a single polygon
+}
+\details{
+For multiple polyogns or a MULTIPOLYGON object use the function \code{\link{totalShapeMetrics}}
 }
 \examples{
 matrix_R <- matrix(c(

--- a/man/stFeatureAxes.Rd
+++ b/man/stFeatureAxes.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/shapeMetricsFromSF.R
 \name{stFeatureAxes}
 \alias{stFeatureAxes}
-\title{Calculate the length of feature axes of an sf polygon}
+\title{Calculate the length of feature axes of a single sf polygon}
 \usage{
 stFeatureAxes(sfPoly)
 }
@@ -13,7 +13,7 @@ stFeatureAxes(sfPoly)
 list; list containing the major and minor axis lengths
 }
 \description{
-Calculate the length of feature axes of an sf polygon
+Calculate the length of feature axes of a single sf polygon
 }
 \examples{
 matrixR <- matrix(c(

--- a/man/totalShapeMetrics.Rd
+++ b/man/totalShapeMetrics.Rd
@@ -18,7 +18,7 @@ Calculate a set of shape metrics of a set of polygons
 \details{
 Calculate a set of shape metrics of a set of polygons.
 The function calculates all metrics that are implemented in the function
-\code{shapeMetrics()}
+\code{\link{shapeMetrics}}
 }
 \examples{
 data(sostaSPE)

--- a/vignettes/StructureReconstructionVignette.Rmd
+++ b/vignettes/StructureReconstructionVignette.Rmd
@@ -340,6 +340,68 @@ cbind(colData(sostaSPE), spatialCoords(sostaSPE)) |>
     facet_wrap(~imageName)
 ```
 
+## Structure boundary vs FOV boundary
+
+A common issue when defining border cells is that the field of view (FOV) 'cuts' the reconstructed polygon. This means that defined border cells may actually be inside the structure. To account for this we define the distance to the FOV border and then exclude the cells that are close to the FOV border.
+
+The fov in this example ranges from coordinates 0 to 128 in the $x$ and $y$ direction. We therefore create polygons that cover the entire field of view. As we have multiple samples we replicate the polygons and name them coorespondingly.
+
+```{r}
+# create the fov bounding box using st_bbox
+fov_bbox <- st_bbox(c(xmin = 0, ymin = 0, xmax = 128, ymax = 128))
+
+# convert to polygon
+fov <- st_as_sfc(fov_bbox)
+
+# one fov per image
+fovBorder <- rep(fov, length(unique(sostaSPE$imageName))) |>
+  st_as_sf()
+
+# name the polygons accordingly
+fovBorder$imageName <- unique(sostaSPE$imageName)
+
+fovBorder
+```
+
+Now we use the function `minBoundaryDistances` to get the distances to the FOV border. 
+
+```{r}
+sostaSPE$fovBorderDist <- minBoundaryDistances(
+  spe = sostaSPE,
+  imageCol = "imageName",
+  structColumn = "imageName", # here any variable that is true for all cells
+  allStructs = fovBorder
+) |> 
+  abs()
+```
+
+```{r}
+cbind(colData(sostaSPE), spatialCoords(sostaSPE)) |>
+    as.data.frame() |>
+    ggplot(aes(x = x, y = y, color = fovBorderDist)) +
+    geom_point(size = 0.25) +
+    facet_wrap(~imageName) +
+    coord_equal() +
+    facet_wrap(~imageName)
+```
+
+We can use the distance to the FOV border to correct the border assingment.
+
+```{r}
+sostaSPE$borderCorrected <- 
+  ifelse(sostaSPE$fovBorderDist > 5, sostaSPE$borderSf, NA)
+```
+
+```{r}
+cbind(colData(sostaSPE), spatialCoords(sostaSPE)) |>
+    as.data.frame() |>
+    ggplot(aes(x = x, y = y, color = borderCorrected)) +
+    geom_point(size = 0.25) +
+    facet_wrap(~imageName) +
+    coord_equal() +
+    facet_wrap(~imageName)
+```
+
 # Session Info
 
 ```{r sessionInfo}

--- a/vignettes/StructureReconstructionVignette.Rmd
+++ b/vignettes/StructureReconstructionVignette.Rmd
@@ -342,9 +342,9 @@ cbind(colData(sostaSPE), spatialCoords(sostaSPE)) |>
 
 ## Structure boundary vs FOV boundary
 
-A common issue when defining border cells is that the field of view (FOV) 'cuts' the reconstructed polygon. This means that defined border cells may actually be inside the structure. To account for this we define the distance to the FOV border and then exclude the cells that are close to the FOV border.
+When defining border cells, the field of view (FOV) can cut through the reconstructed polygon(s). This can cause cells that are actually inside the structure to be classified as border cells. To avoid this, we compute the distance to the FOV boundary and remove cells that are close to it.
 
-The fov in this example ranges from coordinates 0 to 128 in the $x$ and $y$ direction. We therefore create polygons that cover the entire field of view. As we have multiple samples we replicate the polygons and name them coorespondingly.
+The FOV in this example ranges from coordinates 0 to 128 in the $x$ and $y$ direction. We therefore define polygons that span the entire FOV. Since there are multiple samples, we replicate these polygons and label them accordingly.
 
 ```{r}
 # create the fov bounding box using st_bbox
@@ -385,7 +385,7 @@ cbind(colData(sostaSPE), spatialCoords(sostaSPE)) |>
     facet_wrap(~imageName)
 ```
 
-We can use the distance to the FOV border to correct the border assingment.
+We can use the distance to the FOV border to correct the border assignments.
 
 ```{r}
 sostaSPE$borderCorrected <- 


### PR DESCRIPTION
From the `NEWS` file
* clarified difference between `shapeMetric` and `totalShapeMetrics`.
* updated FOV border characterization in vignette.
* changed `minBoundaryDistances` to allow for distance to FOV border characterization
* added "Structure boundary vs FOV boundary" section to vignette.
* added argument to simulate noise in `createPointPatternTissue`
* improved intensity value threshold estimation for reconstruction in `.intensityThreshold`